### PR TITLE
Reword sentences on closures (debatable change)

### DIFF
--- a/briefer_closure_syntax.md
+++ b/briefer_closure_syntax.md
@@ -19,7 +19,7 @@ This is similar to how closures were originally implemented in Javascript.
 ```php
 
 var add1 = function (x) {
-    retun x + 1;
+    return x + 1;
 }
 
 ```
@@ -79,7 +79,7 @@ $result = fn(2);
 
 ```
 
-Exactly what the syntax should be for use`ing variables seems to need to be settled.
+Exactly what the syntax should be for using variables seems to need to be settled.
 
 
 Also, should people be able to set return types for short closures, and what the syntax for that should be.

--- a/briefer_closure_syntax.md
+++ b/briefer_closure_syntax.md
@@ -82,7 +82,7 @@ $result = fn(2);
 Exactly what the syntax should be for using variables seems to need to be settled.
 
 
-Also, should people be able to set return types for short closures, and what the syntax for that should be.
+Also, should people be able to set return types for short closures? And what the syntax for that should be?
 
 
 ## Forecast


### PR DESCRIPTION
This is a separate branch since it's debatable on whether the changes are preferable over what is currently used.

Note: I branched this off of `closures-proofread`, which is why it shows commits from that branch. The only difference between this PR and #21 is 

> Also, should people be able to set return types for short closures? And what the syntax for that should be?